### PR TITLE
commented lines: work with them, and leave comments intact

### DIFF
--- a/gcode-axis-offset.py
+++ b/gcode-axis-offset.py
@@ -6,13 +6,20 @@ axis = sys.argv[2]
 offset = float(sys.argv[3])
 
 with open(filename) as f:
-        lista_linija = f.read().splitlines() 
-
+	lista_linija = f.read().splitlines()
 
 for line in lista_linija:
-  for word in line.split(" "):
-    if (re.search(axis + ".*", word)):
-      print(axis + str(round(float(word[1:]) + offset,4)),end=" ")
-    else:
-      print(word, end=" ")
-  print()
+	if not line.startswith(";") and re.search(axis + ".*", line):
+		codeAndComment = line.split(";")
+		if (codeAndComment[0]):
+			for word in codeAndComment[0].split(" "):
+				if (re.search(axis + ".*", word)):
+					print(axis + str(round(float(word[1:]) + offset,4)),end=" ")
+				else:
+					print(word, end=" ")
+		if len(codeAndComment) > 1:
+			print(";" + codeAndComment[1])
+		else:
+			print()
+	else:
+		print(line)


### PR DESCRIPTION
slic3r (on my Zeus) can generate gcode with comments adjacent to
numbers, e.g.
G0 X0 Y8 F4500; Go to pre-heat location
so we have to split off the comments before assuming that every
"word" after the initial letter is part of a number.
Also, preserve unmodified any lines which are fully commented
or which do not contain movements on the axis of interest.
And use tabs for indentation (personal preference, especially for
Python, such that 1 tab = one indent-level, and visual indentation
in your editor is then just a matter of settings).